### PR TITLE
스프링배치/섹션1: Spring Batch Listener

### DIFF
--- a/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/AdvancedSystemInfiltrationConfig.java
+++ b/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/AdvancedSystemInfiltrationConfig.java
@@ -1,0 +1,87 @@
+package com.system.batch.batchlistener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.Map;
+import java.util.Random;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class AdvancedSystemInfiltrationConfig {
+    private final InfiltrationPlanListener infiltrationPlanListener;
+
+    @Bean
+    public Job systemInfiltrationJob(JobRepository jobRepository, Step reconStep, Step attackStep) {
+        return new JobBuilder("systemInfiltrationJob", jobRepository)
+                .listener(infiltrationPlanListener)
+                .start(reconStep)
+                .next(attackStep)
+                .build();
+    }
+
+    @Bean
+    public Step reconStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("reconStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    Map<String, Object> infiltrationPlan = (Map<String, Object>)
+                            chunkContext.getStepContext()
+                                    .getJobExecutionContext()
+                                    .get("infiltrationPlan");
+                    log.info("침투 준비 단계: {}", infiltrationPlan.get("targetSystem"));
+                    log.info("필요한 도구: {}", infiltrationPlan.get("requiredTools"));
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step attackStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            Tasklet attackStepTasklet  // 주입받은 Tasklet 사용
+    ) {
+        return new StepBuilder("attackStep", jobRepository)
+                .tasklet(attackStepTasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public Tasklet attackStepTasklet(
+            @Value("#{jobExecutionContext['infiltrationPlan']}") Map<String, Object> infiltrationPlan
+    ) {
+        return (contribution, chunkContext) -> {
+            log.info("시스템 공격 중: {}", infiltrationPlan.get("targetSystem"));
+            log.info("목표: {}", infiltrationPlan.get("objective"));
+
+            Random rand = new Random();
+            boolean infiltrationSuccess = rand.nextBoolean();
+
+            if (infiltrationSuccess) {
+                log.info("침투 성공! 획득한 데이터: {}", infiltrationPlan.get("targetData"));
+                contribution.getStepExecution().getJobExecution().getExecutionContext()
+                        .put("infiltrationResult", "TERMINATED");
+            } else {
+                log.info("침투 실패. 시스템이 우리를 감지했다.");
+                contribution.getStepExecution().getJobExecution().getExecutionContext()
+                        .put("infiltrationResult", "DETECTED");
+            }
+
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/BigBrotherJobExecutionListener.java
+++ b/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/BigBrotherJobExecutionListener.java
@@ -1,0 +1,21 @@
+package com.system.batch.batchlistener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class BigBrotherJobExecutionListener implements JobExecutionListener {
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        log.info("시스템 감시 시작. 모든 작업을 내 통제 하에 둔다.");
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        log.info("작업 종료. 할당된 자원 정리 완료.");
+        log.info("시스템 상태: {}", jobExecution.getStatus());
+    }
+}

--- a/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/BigBrotherStepExecutionListener.java
+++ b/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/BigBrotherStepExecutionListener.java
@@ -1,0 +1,57 @@
+package com.system.batch.batchlistener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.annotation.AfterJob;
+import org.springframework.batch.core.annotation.AfterStep;
+import org.springframework.batch.core.annotation.BeforeJob;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+class BigBrotherStepExecutionListener implements StepExecutionListener {
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        log.info("Step 구역 감시 시작. 모든 행동이 기록된다.");
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        log.info("Step 감시 종료. 모든 행동이 기록되었다.");
+        log.info("Big Brother의 감시망에서 벗어날 수 없을 것이다.");
+        return ExitStatus.COMPLETED;
+    }
+}
+
+@Slf4j
+@Component
+class ServerRoomInfiltrationListener {
+    @BeforeJob
+    public void infiltrateServerRoom(JobExecution jobExecution) {
+        log.info("판교 서버실 침투 시작. 보안 시스템 무력화 진행중.");
+    }
+
+    @AfterJob
+    public void escapeServerRoom(JobExecution jobExecution) {
+        log.info("파괴 완료. 침투 결과: {}", jobExecution.getStatus());
+    }
+}
+
+@Slf4j
+@Component
+class ServerRackControlListener {
+    @BeforeStep
+    public void accessServerRack(StepExecution stepExecution) {
+        log.info("서버랙 접근 시작. 콘센트를 찾는 중.");
+    }
+
+    @AfterStep
+    public ExitStatus leaveServerRack(StepExecution stepExecution) {
+        log.info("코드를 뽑아버렸다.");
+        return new ExitStatus("POWER_DOWN");
+    }
+}

--- a/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/InfiltrationPlanListener.java
+++ b/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/InfiltrationPlanListener.java
@@ -1,0 +1,63 @@
+package com.system.batch.batchlistener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+@Slf4j
+@Component
+public class InfiltrationPlanListener implements JobExecutionListener {
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        Map<String, Object> infiltrationPlan = generateInfiltrationPlan();
+        jobExecution.getExecutionContext().put("infiltrationPlan", infiltrationPlan);
+        log.info("새로운 침투 계획이 준비됐다: {}",  infiltrationPlan.get("targetSystem"));
+    }
+
+    private Map<String, Object> generateInfiltrationPlan() {
+        List<String> targets = List.of(
+                "판교 서버실", "안산 데이터센터"
+        );
+        List<String> objectives = List.of(
+                "kill -9 실행", "rm -rf 전개", "chmod 000 적용", "/dev/null로 리다이렉션"
+        );
+        List<String> targetData = List.of(
+                "코어 덤프 파일", "시스템 로그", "설정 파일", "백업 데이터"
+        );
+        List<String> requiredTools = List.of(
+                "USB 킬러", "널 바이트 인젝터", "커널 패닉 유발기", "메모리 시퍼너"
+        );
+
+        Random rand = new Random();
+
+        Map<String, Object> infiltrationPlan = new HashMap<>();
+        infiltrationPlan.put("targetSystem", targets.get(rand.nextInt(targets.size())));
+        infiltrationPlan.put("objective", objectives.get(rand.nextInt(objectives.size())));
+        infiltrationPlan.put("targetData", targetData.get(rand.nextInt(targetData.size())));
+        infiltrationPlan.put("requiredTools", requiredTools.get(rand.nextInt(requiredTools.size())));
+
+        return infiltrationPlan;
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        String infiltrationResult = (String) jobExecution.getExecutionContext().get("infiltrationResult");
+        Map<String, Object> infiltrationPlan = (Map<String, Object>)
+                jobExecution.getExecutionContext().get("infiltrationPlan");
+
+        log.info("타겟 '{}' 침투 결과: {}", infiltrationPlan.get("targetSystem"), infiltrationResult);
+
+        if ("TERMINATED".equals(infiltrationResult)) {
+            log.info("시스템 제거 완료. 다음 타겟 검색 중...");
+        } else {
+            log.info("철수한다. 다음 기회를 노리자.");
+        }
+    }
+}

--- a/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/SystemTerminationConfig.java
+++ b/스프링 배치/kill-batch-system/src/main/java/com/system/batch/batchlistener/SystemTerminationConfig.java
@@ -1,0 +1,76 @@
+package com.system.batch.batchlistener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.listener.ExecutionContextPromotionListener;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.PlatformTransactionManager;
+
+
+@Slf4j
+@Configuration
+public class SystemTerminationConfig {
+    @Bean
+    public Job systemTerminationJob(JobRepository jobRepository, Step scanningStep, Step eliminationStep) {
+        return new JobBuilder("systemTerminationJob", jobRepository)
+                .start(scanningStep)
+                .next(eliminationStep)
+                .build();
+    }
+
+    @Bean
+    public Step scanningStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager
+    ) {
+        return new StepBuilder("scanningStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    String target = "판교 서버실";
+                    ExecutionContext stepContext = contribution.getStepExecution().getExecutionContext();
+                    stepContext.put("targetSystem", target);
+                    log.info("타겟 스캔 완료: {}", target);
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .listener(promotionListener())
+                .build();
+    }
+
+    @Bean
+    public Step eliminationStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            Tasklet eliminationTasklet
+    ) {
+        return new StepBuilder("eliminationStep", jobRepository)
+                .tasklet(eliminationTasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public Tasklet eliminationTasklet(
+            @Value("#{jobExecutionContext['targetSystem']}") String target
+    ) {
+        return (contribution, chunkContext) -> {
+            log.info("시스템 제거 작업 실행: {}", target);
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @Bean
+    public ExecutionContextPromotionListener promotionListener() {
+        ExecutionContextPromotionListener listener = new ExecutionContextPromotionListener();
+        listener.setKeys(new String[]{"targetSystem"});
+        return listener;
+    }
+}


### PR DESCRIPTION
# 스프링배치/섹션1: Spring Batch Listener

## 요약

Readme에 **Listener 섹션** 추가 및 실행 예제 반영
`JobExecutionListener + ExecutionContext`로 **동적 데이터 전달**, `ExecutionContextPromotionListener`로 **Step 간 공유** 패턴 추가

---

## 변경 사항

* 문서: 리스너 종류·호출 시점, 인터페이스/어노테이션 구현, 동적 전달, 승격, 스코프 가이드, 트러블슈팅 요약 추가
* 코드

  * `AdvancedSystemInfiltrationConfig`

    * `systemInfiltrationJob`, `reconStep`, `attackStep` 구성
    * `@StepScope attackStepTasklet`에 `@Value("#{jobExecutionContext['infiltrationPlan']}")` 주입
  * `BigBrotherJobExecutionListener`, `BigBrotherStepExecutionListener` 및 어노테이션 리스너 예시
  * `InfiltrationPlanListener`: 계획 생성 → `jobExecutionContext` 저장, 결과 집계
  * `SystemTerminationConfig`: `scanningStep`에서 값 저장 → `ExecutionContextPromotionListener`로 `targetSystem` 승격 → `eliminationTasklet`에서 주입
* 변경 규모: 1 commit, 6 files changed, +556 / −1

---

## 동기/의도

잡 파라미터로 표현하기 어려운 **실행 중 생성값** 전달 필요
StepExecutionContext의 값 재사용을 위한 **표준 승격 리스너** 도입

---

## 테스트 방법

1. 동적 전달

```bash
./gradlew bootRun --args='--spring.batch.job.name=systemInfiltrationJob'
```

* 기대 로그

  * `beforeJob`에서 infiltrationPlan 준비
  * `reconStep`에서 plan 조회
  * `attackStep`에서 plan 주입 및 infiltrationResult 기록
  * `afterJob`에서 결과 요약

2. Step 간 승격

```bash
./gradlew bootRun --args='--spring.batch.job.name=systemTerminationJob'
```

* 기대 로그

  * `scanningStep` Step EC에 `targetSystem` 저장
  * 승격 리스너로 Job EC에 `targetSystem` 노출
  * `eliminationStep`에서 `@Value("#{jobExecutionContext['targetSystem']}")` 주입 확인

---

## 최종 정리

* 스코프 적용 원칙

  * `@JobScope/@StepScope`는 Tasklet/Reader/Writer/Listener 같은 **컴포넌트**에만 적용
  * `@Bean Job ...`, `@Bean Step ...` 메서드에는 **금지**
* 불변 입력 vs 가변 상태

  * 외부 입력은 JobParameters
  * 실행 중 변하는 값은 ExecutionContext
* 호출 타이밍

  * `beforeJob/beforeStep` 예외 발생 시 해당 단위 실패
  * `afterJob/afterStep` 예외는 상태에 영향 없음

---